### PR TITLE
Move OddsProcessor into analysis package

### DIFF
--- a/src/analysis/base.py
+++ b/src/analysis/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+from feeds.base import OddsFeed
+
+class AnalysisEngine(ABC):
+    """Abstract base class for modules that analyse odds data."""
+
+    def __init__(self, feed: OddsFeed) -> None:
+        self.feed = feed
+
+    @abstractmethod
+    def process_event(self, event: Dict[str, Any], *args, **kwargs):
+        """Analyse odds data for the given event."""
+        raise NotImplementedError

--- a/src/analysis/odds_processor.py
+++ b/src/analysis/odds_processor.py
@@ -14,18 +14,21 @@ from config import Config
 from itertools import zip_longest   # handles uneven list lengths
 from collections.abc import Iterable
 from itertools import product
+from feeds.base import OddsFeed
 from feeds.the_odds_api import TheOddsAPI
+from .base import AnalysisEngine
 
-class OddsProcessor:
+class OddsProcessor(AnalysisEngine):
     """Process and plot prop markets for an event"""
 
-    def __init__(self, event, arb_thresh = 0.01, p_gap: float = 0.075, ev_thresh: float = 0.10, bootstrap: bool = False):
+    def __init__(self, event, feed: OddsFeed | None = None, arb_thresh: float = 0.01,
+                 p_gap: float = 0.075, ev_thresh: float = 0.10, bootstrap: bool = False):
+        super().__init__(feed or TheOddsAPI())
         self.event     = event
         self.arb_thresh  = arb_thresh
         self.p_gap     = p_gap
         self.ev_thresh = ev_thresh
         self.bootstrap = bootstrap
-        self.event_fetcher = TheOddsAPI()
 
 
 
@@ -1157,8 +1160,8 @@ class OddsProcessor:
                 print("\n")
 
             if mode == "live":
-                player_prop_df = self.event_fetcher.get_props_for_todays_events([event], markets=Config.player_prop_markets)
-                player_alt_df = self.event_fetcher.get_props_for_todays_events([event], markets=Config.player_alternate_markets)
+                player_prop_df = self.feed.get_props_for_todays_events([event], markets=Config.player_prop_markets)
+                player_alt_df = self.feed.get_props_for_todays_events([event], markets=Config.player_alternate_markets)
                 player_prop_df = pd.DataFrame(player_prop_df)
                 player_alt_df = pd.DataFrame(player_alt_df)
                 if not os.path.exists(f"{filepath}/player"):
@@ -1258,9 +1261,9 @@ class OddsProcessor:
                 print("\n")
             
             if mode == "live":
-                game_period_df = self.event_fetcher.get_props_for_todays_events([event], markets=Config.game_period_markets)
-                alternate_df = self.event_fetcher.get_props_for_todays_events([event], markets=Config.alt_markets)
-                game_df = self.event_fetcher.get_props_for_todays_events([event], markets=Config.game_markets)
+                game_period_df = self.feed.get_props_for_todays_events([event], markets=Config.game_period_markets)
+                alternate_df = self.feed.get_props_for_todays_events([event], markets=Config.alt_markets)
+                game_df = self.feed.get_props_for_todays_events([event], markets=Config.game_markets)
                 game_period_df = pd.DataFrame(game_period_df)
                 alternate_df = pd.DataFrame(alternate_df)
                 game_df = pd.DataFrame(game_df)

--- a/src/events_handler.py
+++ b/src/events_handler.py
@@ -12,7 +12,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from config            import Config
 from feeds.the_odds_api     import TheOddsAPI
-from odds_processor    import OddsProcessor
+from analysis.odds_processor    import OddsProcessor
 
 class EventsHandler:
     def __init__(
@@ -127,6 +127,7 @@ class EventsHandler:
         # Correctly pass `event` as first arg to OddsProcessor
         proc = OddsProcessor(
             event,
+            feed=self.fetcher,
             arb_thresh=self.arb_thresh,
             p_gap=self.p_gap,
             ev_thresh=self.ev_thresh,

--- a/src/live_events_handler.py
+++ b/src/live_events_handler.py
@@ -11,7 +11,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from events_handler import EventsHandler
 from notifier import TelegramNotifier
-from odds_processor import OddsProcessor
+from analysis.odds_processor import OddsProcessor
 from config import Config
 from feeds.the_odds_api import TheOddsAPI
 
@@ -126,6 +126,7 @@ class LiveSchedulerWithNotifications(EventsHandler):
         # Create processor
         proc = OddsProcessor(
             event,
+            feed=self.fetcher,
             arb_thresh=self.arb_thresh,
             p_gap=self.p_gap,
             ev_thresh=self.ev_thresh,

--- a/src/phone_utils.py
+++ b/src/phone_utils.py
@@ -1,0 +1,1 @@
+from utils.phone_utils import *

--- a/src/test_notifier_integration.py
+++ b/src/test_notifier_integration.py
@@ -21,7 +21,7 @@ sys.path.insert(0, current_dir)
 sys.path.insert(0, parent_dir)
 
 from notifier import TelegramNotifier
-from odds_processor import OddsProcessor
+from analysis.odds_processor import OddsProcessor
 from feeds.the_odds_api import TheOddsAPI
 from config import Config
 

--- a/tests/test_notifier_integration.py
+++ b/tests/test_notifier_integration.py
@@ -19,7 +19,7 @@ sys.path.insert(0, src_path)
 
 from config import Config
 from feeds.the_odds_api import TheOddsAPI
-from odds_processor import OddsProcessor
+from analysis.odds_processor import OddsProcessor
 from notifier import TelegramNotifier
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- introduce `analysis` package with abstract `AnalysisEngine`
- move `odds_processor` into new package and subclass `AnalysisEngine`
- update odds fetching to use an injected `OddsFeed`
- adjust event handlers and tests to import from `analysis.odds_processor`
- expose `phone_utils` at the package root for tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d17ab7748325ae4c5714841c1542